### PR TITLE
fix(rust): generate witness IDs in did:key format

### DIFF
--- a/implementations/rust/src/generate.rs
+++ b/implementations/rust/src/generate.rs
@@ -149,10 +149,17 @@ fn build_parameters(p: &StepParams, keys: &HashMap<String, KeyInfo>) -> Result<P
     let witness = if let Some(wc) = &p.witness {
         let mut builder = Witnesses::builder().threshold(wc.threshold);
         for we in &wc.witnesses {
-            let mb = keys.get(&we.id)
-                .map(|k| k.pub_multibase.clone())
-                .unwrap_or_else(|| we.id.clone());
-            builder = builder.witness(Multibase::new(mb));
+            let witness_id = keys
+                .get(&we.id)
+                .map(|k| format!("did:key:{}", k.pub_multibase))
+                .unwrap_or_else(|| {
+                    if we.id.starts_with("did:key:") {
+                        we.id.clone()
+                    } else {
+                        format!("did:key:{}", we.id)
+                    }
+                });
+            builder = builder.witness(Multibase::new(witness_id));
         }
         Some(Arc::new(builder.build()
             .map_err(|e| format!("build witnesses: {e:?}"))?))
@@ -175,9 +182,11 @@ fn build_parameters(p: &StepParams, keys: &HashMap<String, KeyInfo>) -> Result<P
 // ---------------------------------------------------------------------------
 
 fn all_witness_secrets(keys: &HashMap<String, KeyInfo>) -> HashMap<String, Secret> {
-    keys.values()
-        .map(|k| (k.pub_multibase.clone(), k.secret.clone()))
-        .collect()
+    let mut out = HashMap::default();
+    for k in keys.values() {
+        out.insert(format!("did:key:{}", k.pub_multibase), k.secret.clone());
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`generate.rs` currently generates witness ID as bare multibase, amended to generate as `did:key:` matching normative expectation in webvh spec